### PR TITLE
Ensure RAG JSON schema migrates cleanly and surfaces warnings

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -545,12 +545,14 @@ export default function AppShell({ state, setState, showToast, addToHistory }: A
           cardDensity: state.viewMode,
           noExternalProviders: false
         }}
-        onSettingsChange={(settings) => setState(prev => ({ 
-          ...prev, 
+        onSettingsChange={(settings) => setState(prev => ({
+          ...prev,
           theme: settings.themeMode === 'dark' ? 'dark' : 'light',
           viewMode: settings.viewMode === 'list' ? 'compact' : 'comfort'
         }))}
         onShowToast={showToast}
+        ragStats={state.ragStats}
+        ragWarnings={state.ragWarnings}
       />
     </div>
   );

--- a/src/data/usePrograms.ts
+++ b/src/data/usePrograms.ts
@@ -1,43 +1,108 @@
 // src/data/usePrograms.ts
 import { useEffect, useState } from 'react';
-import { buildProgramsFromRag, Program, RagMeta, RagChunk } from './programs.fromRag';
+import { buildProgramsFromRag, Program, RagMeta as DerivedRagMeta, RagChunk as DerivedRagChunk } from './programs.fromRag';
+import { loadRagFiles } from '../rag/ingest';
+import type { RagStats, RagMeta, RagChunk } from '../rag/schema';
 
 export function usePrograms() {
-  const [state, set] = useState<{ programs: Program[]; source: 'rag' | 'empty'; loading: boolean; error?: string }>({
+  const [state, set] = useState<{
+    programs: Program[];
+    source: 'rag' | 'empty';
+    loading: boolean;
+    error?: string;
+    stats: RagStats | null;
+    warnings: string[];
+  }>({
     programs: [],
     source: 'rag',
     loading: true,
+    stats: null,
+    warnings: []
   });
 
   useEffect(() => {
     let cancelled = false;
-    const BASE = (import.meta.env.BASE_URL ?? '/').replace(/\/$/, '');
-    const j = (p: string) => fetch(`${BASE}${p}`, { cache: 'no-store' }).then(r => (r.ok ? r.json() : null));
 
     (async () => {
       try {
-        const [meta, chunks] = await Promise.all<[RagMeta[] | null, RagChunk[] | null]>([
-          j('/rag/programMeta.json'),
-          j('/rag/chunks.json'),
-        ]);
+        const { stats, meta, chunks, warnings } = await loadRagFiles();
 
-        if (!cancelled && Array.isArray(meta) && meta.length && Array.isArray(chunks) && chunks.length) {
-          const progs = buildProgramsFromRag(meta, chunks);
-          set({ programs: progs, source: 'rag', loading: false });
+        if (cancelled) return;
+
+        const normalizedMeta: DerivedRagMeta[] = (meta as RagMeta)
+          .map(item => {
+            const programId = item.programId ?? item.id;
+            const title = item.title ?? '';
+            const pagesRaw = Array.isArray(item.pages) ? item.pages : [item.startPage, item.endPage];
+            const start = Number(pagesRaw?.[0] ?? item.startPage ?? 0) || 0;
+            const end = Number(pagesRaw?.[1] ?? item.endPage ?? pagesRaw?.[0] ?? item.startPage ?? start) || start;
+            if (!programId || !title) return null;
+            return {
+              programId,
+              title,
+              pages: [start, end] as [number, number],
+              stand: (item as any).stand ?? null,
+              status: (item as any).status ?? null
+            } satisfies DerivedRagMeta;
+          })
+          .filter((m): m is DerivedRagMeta => !!m);
+
+        const normalizedChunks: DerivedRagChunk[] = (chunks as RagChunk[])
+          .map(chunk => {
+            const page = Number(chunk.page ?? chunk.seite ?? 0) || 0;
+            const section = typeof chunk.section === 'string' ? chunk.section : '';
+            const text = typeof chunk.text === 'string' ? chunk.text : '';
+            if (!text) return null;
+            return {
+              page,
+              section,
+              text,
+              status: (chunk as any).status ?? null,
+              stand: (chunk as any).stand ?? null
+            } satisfies DerivedRagChunk;
+          })
+          .filter((c): c is DerivedRagChunk => !!c);
+
+        if (normalizedMeta.length && normalizedChunks.length) {
+          const progs = buildProgramsFromRag(normalizedMeta, normalizedChunks);
+          const derivedStats = stats ? { ...stats } : null;
+          const derivedWarnings = [...warnings];
+
+          if (derivedStats) {
+            if (!derivedStats.programs && normalizedMeta.length) {
+              derivedStats.programs = normalizedMeta.length;
+              derivedWarnings.push('stats.programs missing - derived from meta length');
+            }
+            if (!derivedStats.chunks && normalizedChunks.length) {
+              derivedStats.chunks = normalizedChunks.length;
+              derivedWarnings.push('stats.chunks missing - derived from chunk length');
+            }
+          }
+
+          set({ programs: progs, source: 'rag', loading: false, stats: derivedStats, warnings: derivedWarnings });
           return;
         }
-        
+
         if (!cancelled) {
-          console.warn('[RAG] Dateien fehlen', { 
-            meta: Array.isArray(meta) && meta.length > 0, 
-            chunks: Array.isArray(chunks) && chunks.length > 0 
+          console.warn('[RAG] Dateien fehlen', {
+            meta: normalizedMeta.length > 0,
+            chunks: normalizedChunks.length > 0
           });
         }
       } catch (e) {
         console.warn('[Programs] rag load failed', e);
       }
 
-      if (!cancelled) set({ programs: [], source: 'empty', loading: false, error: 'Keine Broschürendaten gefunden' });
+      if (!cancelled) {
+        set({
+          programs: [],
+          source: 'empty',
+          loading: false,
+          error: 'Keine Broschürendaten gefunden',
+          stats: null,
+          warnings: []
+        });
+      }
     })();
 
     return () => {

--- a/src/rag/__tests__/schema.test.ts
+++ b/src/rag/__tests__/schema.test.ts
@@ -1,0 +1,32 @@
+import {
+  migrateStats,
+  migrateProgramMeta,
+  migrateChunks,
+  validateStats,
+  validateMeta,
+  validateChunks
+} from '../schema';
+
+it('migrates snake_case to camelCase', () => {
+  const s = migrateStats({ build_id: 'x', built_at: 't', pages: 1, programs: 2, chunks: 3, sections_count: { a: 1 } });
+  expect(s.buildId).toBe('x');
+  expect(s.sectionsCount?.a).toBe(1);
+});
+
+it('migrates programMeta start_page/end_page', () => {
+  const m = migrateProgramMeta([{ id: 'a', title: 'T', start_page: 10, end_page: 12 }]);
+  expect(m[0].startPage).toBe(10);
+  expect(m[0].pages).toEqual([10, 12]);
+});
+
+it('migrates chunks program_id + seite→page', () => {
+  const c = migrateChunks([{ id: 'x', program_id: 'p1', section: 'allgemein', seite: 5, text: 't' }]);
+  expect(c[0].programId).toBe('p1');
+  expect(c[0].page).toBe(5);
+});
+
+it('validates presence of required fields', () => {
+  expect(validateStats({} as any).length).toBeGreaterThan(0);
+  expect(validateMeta([{ id: 'x', programId: 'p', title: 't' }]).length).toBe(0);
+  expect(validateChunks([{ id: 'x', programId: 'p', section: 's', text: 't' }]).length).toBe(0);
+});

--- a/src/rag/schema.ts
+++ b/src/rag/schema.ts
@@ -54,3 +54,124 @@ export interface IngestionStats {
   programsFound: number;
   processingTime: number;
 }
+
+export type RagStats = {
+  buildId: string;
+  builtAt: string;
+  pages: number;
+  programs: number;
+  chunks: number;
+  sectionsCount: Record<string, number>;
+  facets?: Record<string, any>;
+  source?: string;
+};
+
+export type RagMeta = Array<{
+  id: string;
+  title: string;
+  programId?: string;
+  startPage?: number;
+  endPage?: number;
+  pages?: [number, number];
+  provider?: string;
+  group?: string;
+  container?: boolean;
+}>;
+
+export type RagChunk = {
+  id: string;
+  programId: string;
+  section: string;
+  page?: number;
+  seite?: number;
+  text: string;
+};
+
+// -- Utilities ---------------------------------------------------------------
+const mapKeys = (obj: any, map: Record<string, string>) => {
+  if (!obj || typeof obj !== 'object') return obj;
+  if (Array.isArray(obj)) {
+    return (obj as any[]).map(v => mapKeys(v, map));
+  }
+  const out: any = {};
+  for (const [k, v] of Object.entries(obj)) {
+    const nk = map[k] ?? k;
+    out[nk] = typeof v === 'object' && v !== null ? mapKeys(v, map) : v;
+  }
+  return out;
+};
+
+export function migrateStats(input: any): RagStats {
+  const mapped = mapKeys(input, {
+    build_id: 'buildId',
+    built_at: 'builtAt',
+    sections_count: 'sectionsCount'
+  });
+  const stats = {
+    buildId: mapped.buildId ?? String(mapped.build_id ?? ''),
+    builtAt: mapped.builtAt ?? mapped.built_at ?? '',
+    pages: Number(mapped.pages ?? mapped.totalPages ?? 0) || 0,
+    programs: Number(mapped.programs ?? mapped.programsFound ?? mapped.program_count ?? 0) || 0,
+    chunks: Number(mapped.chunks ?? mapped.totalChunks ?? mapped.chunk_count ?? 0) || 0,
+    sectionsCount: mapped.sectionsCount ?? {},
+    facets: mapped.facets,
+    source: mapped.source
+  } satisfies RagStats;
+  return stats;
+}
+
+export function migrateProgramMeta(input: any): RagMeta {
+  const arr = Array.isArray(input) ? input : [];
+  const mapped = mapKeys(arr, {
+    start_page: 'startPage',
+    end_page: 'endPage',
+    program_id: 'programId',
+    gruppe: 'group'
+  }) as any[];
+  return mapped.map(m => {
+    if (!m.pages && (m.startPage != null || m.endPage != null)) {
+      m.pages = [m.startPage ?? null, m.endPage ?? null];
+    }
+    if (!m.programId && m.id) {
+      m.programId = m.id;
+    }
+    return m;
+  }) as RagMeta;
+}
+
+export function migrateChunks(input: any): RagChunk[] {
+  const arr = Array.isArray(input) ? input : [];
+  const mapped = mapKeys(arr, {
+    program_id: 'programId'
+  }) as any[];
+  return mapped.map(c => {
+    if (c.seite && !c.page) c.page = c.seite;
+    return c;
+  }) as RagChunk[];
+}
+
+export function validateStats(s: RagStats | undefined | null): string[] {
+  const errs: string[] = [];
+  if (!s || typeof s !== 'object') return ['stats: not an object'];
+  if (!s.buildId) errs.push('stats.buildId missing');
+  if (typeof s.programs !== 'number' || Number.isNaN(s.programs)) errs.push('stats.programs missing/NaN');
+  if (typeof s.chunks !== 'number' || Number.isNaN(s.chunks)) errs.push('stats.chunks missing/NaN');
+  if (!s.sectionsCount || typeof s.sectionsCount !== 'object') errs.push('stats.sectionsCount missing');
+  return errs;
+}
+
+export function validateMeta(meta: RagMeta | undefined | null): string[] {
+  const errs: string[] = [];
+  if (!Array.isArray(meta)) return ['programMeta: not an array'];
+  const bad = meta.find(m => ((!m.id && !m.programId) || !m.title));
+  if (bad) errs.push('programMeta: entry without id/programId/title');
+  return errs;
+}
+
+export function validateChunks(ch: RagChunk[] | undefined | null): string[] {
+  const errs: string[] = [];
+  if (!Array.isArray(ch)) return ['chunks: not an array'];
+  const bad = ch.find(c => !c.id || !c.programId || !c.section || !c.text);
+  if (bad) errs.push('chunks: entry missing id/programId/section/text');
+  return errs;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { RagStats } from './rag/schema';
+
 export interface Program {
   id: string;
   name: string;
@@ -114,4 +116,6 @@ export interface AppState {
   history: HistoryEntry[];
   theme: 'light' | 'dark' | 'high-contrast';
   viewMode: 'comfort' | 'compact';
+  ragStats: RagStats | null;
+  ragWarnings: string[];
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "types": ["vitest/globals", "vite/client"]
+  },
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },


### PR DESCRIPTION
## Summary
- add RAG schema migration and validation helpers with coverage for stats, meta and chunk payloads
- load public/rag JSON through a BASE_URL-aware helper that migrates snake_case keys and propagates warnings into usePrograms
- persist RAG stats/warnings in app state and surface build/program/chunk counts plus schema alerts in the settings UI

## Testing
- pnpm i
- pnpm build
- pnpm test -u

------
https://chatgpt.com/codex/tasks/task_e_68dad2fbfa888325842b6af2aedf1c4f