### PR TITLE
Normalize program tag rendering and clean card layouts

### DIFF
--- a/src/components/cards/ProgramCardCompact.tsx
+++ b/src/components/cards/ProgramCardCompact.tsx
@@ -1,18 +1,15 @@
 import type { Program } from '@/types/program';
 import { hasList, hasText } from '@/lib/ui/guards';
-import { prettyFoerderart, prettyAntragsweg, asText } from '@/lib/text/normalizeProgram';
+import { prettyFoerderart, prettyAntragsweg, asText, normalizeProgram } from '@/lib/text/normalizeProgram';
 
-export function ProgramCardCompact({ p, onOpen }:{ p: Program; onOpen?: (id:string)=>void }) {
+export function ProgramCardCompact({ p:raw, onOpen }:{ p: Program; onOpen?: (id:string)=>void }) {
+  const p = normalizeProgram(raw);
   const foerderart = prettyFoerderart(p.foerderart)?.[0];
   const antrag = prettyAntragsweg(p.antragsweg)?.[0];
   const frist = asText(p.frist);
-
-  const limitList = (items?: string[]) => {
-    if (!Array.isArray(items) || items.length === 0) return undefined;
-    const first = items.slice(0, 3);
-    if (items.length > 3) first.push(`+${items.length - 3} mehr`);
-    return first.join(', ');
-  };
+  const fmt = (v?: string[]) => (Array.isArray(v) && v.length)
+    ? v.slice(0,2).join(', ') + (v.length>2?`, +${v.length-2} mehr`:'')
+    : undefined;
 
   return (
     <div className="rounded-xl border border-gray-200 px-3 py-2 hover:shadow-sm transition-shadow bg-white">
@@ -53,11 +50,6 @@ export function ProgramCardCompact({ p, onOpen }:{ p: Program; onOpen?: (id:stri
             {p.region}
           </span>
         )}
-        {typeof p.region === 'string' && p.region && (
-          <span className="border border-gray-300 bg-gray-50 rounded-full px-2 py-0.5">
-            {p.region}
-          </span>
-        )}
       </div>
       {hasText(p.summary) && (
         <p className="mt-1.5 text-xs leading-snug text-gray-700 line-clamp-2">{p.summary}</p>
@@ -66,13 +58,13 @@ export function ProgramCardCompact({ p, onOpen }:{ p: Program; onOpen?: (id:stri
         {hasList(p.zielgruppe) && (
           <div>
             <span className="text-gray-500">Zielgruppe: </span>
-            <span className="text-gray-700">{limitList(p.zielgruppe)}</span>
+            <span className="text-gray-700">{fmt(p.zielgruppe!)}</span>
           </div>
         )}
         {hasList(p.voraussetzungen) && (
           <div>
             <span className="text-gray-500">Voraussetzungen: </span>
-            <span className="text-gray-700">{limitList(p.voraussetzungen)}</span>
+            <span className="text-gray-700">{fmt(p.voraussetzungen!)}</span>
           </div>
         )}
       </div>

--- a/src/components/cards/ProgramCardV2.tsx
+++ b/src/components/cards/ProgramCardV2.tsx
@@ -1,19 +1,20 @@
 import type { Program } from '@/types/program';
 import { hasList, hasText } from '@/lib/ui/guards';
 import { FieldRow } from './FieldRow';
-import { prettyFoerderart, prettyAntragsweg, asText } from '@/lib/text/normalizeProgram';
+import { prettyFoerderart, prettyAntragsweg, asText, normalizeProgram } from '@/lib/text/normalizeProgram';
 
-export function ProgramCardV2({ p, onOpen }:{ p: Program; onOpen?: (id:string)=>void }) {
+function fmtList(v?: string[], limit=3): string | undefined {
+  if (!Array.isArray(v) || v.length===0) return undefined;
+  const shown = v.slice(0, limit).join(', ');
+  const more = v.length - limit;
+  return more > 0 ? `${shown}, +${more} mehr` : shown;
+}
+
+export function ProgramCardV2({ p:raw, onOpen }:{ p: Program; onOpen?: (id:string)=>void }) {
+  const p = normalizeProgram(raw);
   const art = prettyFoerderart(p.foerderart)?.[0];
   const antrag = prettyAntragsweg(p.antragsweg)?.[0];
   const frist = asText(p.frist);
-
-  const limitList = (items?: string[]) => {
-    if (!Array.isArray(items) || items.length === 0) return undefined;
-    const first = items.slice(0, 3);
-    if (items.length > 3) first.push(`+${items.length - 3} mehr`);
-    return first.join(', ');
-  };
 
   return (
     <div className="rounded-2xl border p-4 hover:shadow-sm transition min-h-[220px] bg-white">
@@ -54,10 +55,10 @@ export function ProgramCardV2({ p, onOpen }:{ p: Program; onOpen?: (id:string)=>
         <p className="mt-3 text-sm leading-relaxed line-clamp-3 text-gray-700">{p.summary}</p>
       )}
 
-      <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
+      <div className="mt-3 flex flex-col gap-1.5">
         {hasText(p.region) && <FieldRow label="Region" value={p.region} />}
-        {hasList(p.zielgruppe) && <FieldRow label="Zielgruppe" value={limitList(p.zielgruppe)} />}
-        {hasList(p.voraussetzungen) && <FieldRow label="Voraussetzungen" value={limitList(p.voraussetzungen)} />}
+        {hasList(p.zielgruppe) && <FieldRow label="Zielgruppe" value={fmtList(p.zielgruppe!)} />}
+        {hasList(p.voraussetzungen) && <FieldRow label="Voraussetzungen" value={fmtList(p.voraussetzungen!)} />}
       </div>
     </div>
   );

--- a/src/lib/text/__tests__/normalizeProgram.test.ts
+++ b/src/lib/text/__tests__/normalizeProgram.test.ts
@@ -1,7 +1,7 @@
 import { prettyFoerderart, prettyAntragsweg, canonicalRegion, cleanText, normalizeProgram } from '../normalizeProgram';
 
 it('dedupliziert foerderart und mappt Synonyme', () => {
-  expect(prettyFoerderart(['Kurs', 'kurskosten', 'Kurskosten'])).toEqual(['kurskosten']);
+  expect(prettyFoerderart(['Kurs', 'kurskosten', 'Kurskosten'])).toEqual(['Kurskosten']);
 });
 
 it('mappt antragsweg lesbar', () => {
@@ -31,7 +31,7 @@ it('normalizeProgram kürzt Summary und bereinigt Listen', () => {
   });
 
   expect(program.summary?.endsWith('…')).toBe(true);
-  expect(program.foerderart).toBe('kurskosten');
+  expect(program.foerderart).toBe('Kurskosten');
   expect(program.antragsweg).toBe('eAMS');
   expect(program.zielgruppe).toEqual(['Beschäftigte']);
   expect(program.voraussetzungen).toEqual(['Nachweis', 'Wohnsitz OÖ']);

--- a/src/lib/text/__tests__/tags.test.ts
+++ b/src/lib/text/__tests__/tags.test.ts
@@ -1,0 +1,16 @@
+import { shortTag, normalizeList } from '@/lib/text/normalizeProgram';
+
+describe('shortTag', () => {
+  it('filtert Absätze & Sätze', () => {
+    expect(shortTag('AK OÖ, Mitglieder')).toBe('AK OÖ, Mitglieder');
+    expect(shortTag('Wer wird gefördert?')).toBeUndefined();
+    expect(shortTag('Das ist ein sehr sehr sehr sehr langer Eintrag der abgelehnt wird.')).toBeUndefined();
+  });
+});
+
+describe('normalizeList', () => {
+  it('dedupliziert und filtert', () => {
+    const out = normalizeList(['AK OÖ Mitglieder', 'Wer wird gefördert?', 'AK OÖ Mitglieder']);
+    expect(out).toEqual(['AK OÖ Mitglieder']);
+  });
+});

--- a/src/lib/text/normalizeProgram.ts
+++ b/src/lib/text/normalizeProgram.ts
@@ -1,4 +1,4 @@
-import type { Program } from '../../types/program';
+import type { Program } from '@/types/program';
 
 // --- Mappings ---
 const FOERDERART_MAP: Record<string,string> = {
@@ -7,27 +7,44 @@ const FOERDERART_MAP: Record<string,string> = {
   'lohn':'lohnkostenzuschuss','gehalt':'lohnkostenzuschuss','lohnkostenzuschuss':'lohnkostenzuschuss',
   'betrieb':'betrieb','invest':'betrieb','anschaffung':'betrieb'
 };
-
 const ANTRAG_MAP: Record<string,string> = {
   'eams':'eAMS','e-ams':'eAMS','ams':'eAMS',
   'traeger_direkt':'Träger direkt','träger direkt':'Träger direkt','traeger direkt':'Träger direkt',
   'land_ooe':'Land OÖ','wko':'WKO OÖ','wk oö':'WKO OÖ','online':'Online-Formular','email':'E-Mail','persoenlich':'Persönlich'
 };
 
+const TITLE_CASE: Record<string,string> = {
+  'kurskosten':'Kurskosten',
+  'beratung':'Beratung',
+  'lohnkostenzuschuss':'Lohnkostenzuschuss',
+  'betrieb':'Betrieb'
+};
+
+const OCR_NOISE = [
+  /scanne\s+den\s+link\d+/i,
+  /kontakt\s+.*?straße.*?\d+/i
+];
+
+const STOP_PHRASES = [
+  'wer wird gefördert','wer wird gefoerdert',
+  'was wird gefördert','was wird gefoerdert',
+  'fördervoraussetzungen','foerdervoraussetzungen',
+  'kurzüberblick','kurzueberblick'
+];
+
 export function dedup<T>(arr?: T[] | null): T[] | undefined {
   if (!Array.isArray(arr)) return undefined;
-  const seen = new Set<string>(); 
+  const seen = new Set<string>();
   const out: T[] = [];
   for (const x of arr) {
     const k = String(x).trim().toLowerCase();
     if (!k || seen.has(k)) continue;
-    seen.add(k); 
+    seen.add(k);
     out.push(x);
   }
   return out.length ? out : undefined;
 }
 
-// Neu (export): beliebige Eingaben → String extrahieren
 export function asText(v: any): string | undefined {
   if (v == null) return undefined;
   if (typeof v === 'string') return v.trim() || undefined;
@@ -37,67 +54,25 @@ export function asText(v: any): string | undefined {
     return asText(first);
   }
   if (typeof v === 'object') {
-    // häufige Felder: typ/type/value/label/name
     const cand = v.typ ?? v.type ?? v.value ?? v.label ?? v.name ?? v.text ?? v.title;
     if (cand) return asText(cand);
   }
   try { return JSON.stringify(v); } catch { return undefined; }
 }
 
-export function prettyFoerderart(v?: any) {
-  const arr = Array.isArray(v) ? v : (v ? [v] : []);
-  const mapped = arr.map((s: any) => {
-    const text = asText(s);
-    if (!text) return null;
-    const k = text.toLowerCase();
-    const hit = Object.keys(FOERDERART_MAP).find(p => k.includes(p));
-    return hit ? FOERDERART_MAP[hit] : text.trim();
-  }).filter(Boolean) as string[];
-  return dedup(mapped);
-}
-
-export function prettyAntragsweg(v?: any) {
-  const arr = Array.isArray(v) ? v : (v ? [v] : []);
-  const mapped = arr.map((s: any) => {
-    const text = asText(s);
-    if (!text) return null;
-    const k = text.toLowerCase().replace(/\s+/g,' ').trim();
-    const hit = Object.keys(ANTRAG_MAP).find(p => k.includes(p));
-    return hit ? ANTRAG_MAP[hit] : text.trim();
-  }).filter(Boolean) as string[];
-  return dedup(mapped);
-}
-
-export function canonicalRegion(t?: string) {
-  if (!t) return undefined;
-  const normalized = t.toLowerCase();
-  const translit = normalized
-    .replace(/ö/g, 'oe')
-    .replace(/ä/g, 'ae')
-    .replace(/ü/g, 'ue')
-    .replace(/ß/g, 'ss');
-  if (normalized.includes('österreichweit') || translit.includes('osterreichweit') || normalized.includes('bundesweit')) {
-    return 'Österreichweit';
-  }
-  if (
-    normalized.includes('oberösterreich') ||
-    translit.includes('oberoesterreich') ||
-    /\boo(e)?\b/.test(translit)
-  ) {
-    return 'Oberösterreich';
-  }
-  return undefined;
-}
-
-const OCR_NOISE = [
-  /scanne\s+den\s+link\d+/i,
-  /kontakt\s+.*?straße.*?\d+/i
-];
-
 export function cleanText(s?: string) {
   if (!s) return s;
-  let t = s.replace(/\s+/g,' ').replace(/\s+,/g,',').trim();
+  let t = s
+    .replace(/\s+/g,' ')
+    .replace(/\s+,/g,',')
+    .trim();
   for (const rx of OCR_NOISE) t = t.replace(rx,'');
+  t = t
+    .replace(/Scanne den Link\d*/gi,'')
+    .replace(/Wer wird gef(ö|oe)rdert\??/gi,'')
+    .replace(/Was wird gef(ö|oe)rdert\??/gi,'')
+    .replace(/F(ö|oe)rdervoraussetzungen/gi,'')
+    .replace(/Kur(zu|z)berblick/gi,'');
   t = t.replace(/^(\?|·|•|-)\s*/,'').trim();
   return t || undefined;
 }
@@ -109,16 +84,93 @@ export function clampWords(s?: string, max=55) {
   return parts.slice(0,max).join(' ') + ' …';
 }
 
+export function shortTag(s?: string): string | undefined {
+  if (!s) return undefined;
+  const t = s.trim();
+  if (!/[A-Za-zÄÖÜäöüß]/.test(t)) return undefined;
+  if (/[.!?]$/.test(t)) return undefined;
+  if (t.length > 60) return undefined;
+  if (t.split(/\s+/).length > 9) return undefined;
+  const low = t.toLowerCase();
+  if (STOP_PHRASES.some(p => low.includes(p))) return undefined;
+  return t;
+}
+
+export function normalizeList(v: any): string[] | undefined {
+  const arr = (Array.isArray(v) ? v : (v != null ? [v] : []))
+    .map(asText)
+    .filter(Boolean)
+    .map(cleanText)
+    .map(shortTag)
+    .filter(Boolean) as string[];
+  return dedup(arr);
+}
+
+export function prettyFoerderart(v?: any) {
+  const arr = (Array.isArray(v) ? v : (v != null ? [v] : [])).map(asText).filter(Boolean) as string[];
+  const mapped = arr.map(s => {
+    const k = s.toLowerCase();
+    const hit = Object.keys(FOERDERART_MAP).find(p => k.includes(p));
+    const norm = hit ? FOERDERART_MAP[hit] : s.trim();
+    return TITLE_CASE[norm] ?? (norm.slice(0,1).toUpperCase()+norm.slice(1));
+  });
+  return dedup(mapped);
+}
+
+export function prettyAntragsweg(v?: any) {
+  const arr = (Array.isArray(v) ? v : (v != null ? [v] : [])).map(asText).filter(Boolean) as string[];
+  const mapped = arr.map(s => {
+    const k = s.toLowerCase().replace(/\s+/g,' ').trim();
+    const hit = Object.keys(ANTRAG_MAP).find(p => k.includes(p));
+    return hit ? ANTRAG_MAP[hit] : s.trim();
+  });
+  return dedup(mapped);
+}
+
+const REGION_CANON = [
+  { rx: /(ober(ö|oe)sterreich)/i, label:'Oberösterreich' },
+  { rx: /\b(österreichweit|bundesweit)\b/i, label:'Österreichweit' },
+];
+export function canonicalRegion(t?: any) {
+  const s = asText(t);
+  if (!s) return undefined;
+  const normalized = s.toLowerCase();
+  const translit = normalized
+    .replace(/ö/g,'oe')
+    .replace(/ä/g,'ae')
+    .replace(/ü/g,'ue')
+    .replace(/ß/g,'ss');
+  if (REGION_CANON[1].rx.test(normalized)) return 'Österreichweit';
+  if (REGION_CANON[0].rx.test(normalized) || translit.includes('oberoesterreich') || /\boo(e)?\b/.test(translit)) {
+    return 'Oberösterreich';
+  }
+  return undefined;
+}
+
 export function normalizeProgram(p: Program): Program {
+  const ziel = normalizeList(p.zielgruppe) ?? [];
+  const vor  = normalizeList(p.voraussetzungen) ?? [];
   return {
     ...p,
     foerderart: prettyFoerderart(p.foerderart)?.[0],
     antragsweg: prettyAntragsweg(p.antragsweg)?.[0],
-    region: canonicalRegion(asText(p.region)) ?? asText(p.region),
-    zielgruppe: dedup((Array.isArray(p.zielgruppe)?p.zielgruppe:[])
-      .map(asText).filter(Boolean).map(cleanText) as string[]),
-    voraussetzungen: dedup((Array.isArray(p.voraussetzungen)?p.voraussetzungen:[])
-      .map(asText).filter(Boolean).map(cleanText) as string[]),
-    summary: clampWords(cleanText(asText(p.summary)), 55)
+    region: canonicalRegion(p.region) ?? asText(p.region),
+    frist: asText(p.frist),
+    zielgruppe: dedup(ziel),
+    voraussetzungen: dedup(vor),
+    summary: clampWords(cleanText(asText(p.summary)), 55),
   };
 }
+
+export default {
+  dedup,
+  asText,
+  cleanText,
+  clampWords,
+  shortTag,
+  normalizeList,
+  prettyFoerderart,
+  prettyAntragsweg,
+  canonicalRegion,
+  normalizeProgram,
+};


### PR DESCRIPTION
## Summary
- extend program normalization with short tag filtering, title-cased badges, and defensive region detection
- update program cards to use normalized data, display single-column details, and cap visible tags with +N indicator
- add regression tests covering tag normalization helpers

## Testing
- pnpm test -- --runInBand
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dbf26724908325916298375ed2df73